### PR TITLE
fix(aquedux-client): fix var rename

### DIFF
--- a/packages/aquedux-client/src/network/middleware.js
+++ b/packages/aquedux-client/src/network/middleware.js
@@ -16,7 +16,7 @@ const clientMiddleware = _store => next => action => {
     logger.trace({
       who: 'aquedux-middleware',
       what: 'dispatch action over aquedux',
-      data: water
+      data: action
     })
 
     eventHub.raise(fromConstants.EVENT_SEND, action)


### PR DESCRIPTION
This rename was missing in #11 