### PR TITLE
fix(aquedux-server): Fix redis connection initialization order

### DIFF
--- a/packages/aquedux-server/src/network/server.js
+++ b/packages/aquedux-server/src/network/server.js
@@ -10,6 +10,7 @@ import logger from '../utils/logger'
 import actions from '../actions'
 import actionTypes from '../constants/actionTypes'
 import { selectors } from '../reducers'
+import { initRedisConnection } from '../redis/connections'
 
 // Managers.
 import tankManager from '../managers/tankManager'
@@ -32,6 +33,8 @@ export const getOwnId = () => {
 
 const createAqueduxServer = (store: Store, options: any = {}) => {
   const { onConnection, onClose, routePrefix } = configManager.setConfig(options)
+
+  initRedisConnection()
 
   // Bind ownId to store.
   ownId = () => selectors.queue.getId(store.getState())

--- a/packages/aquedux-server/src/redis/connections.js
+++ b/packages/aquedux-server/src/redis/connections.js
@@ -22,20 +22,6 @@ const retry_strategy = options => {
   return Math.min(options.attempt * options.attempt * 100, 3000)
 }
 
-/**
- *  Create the initial Redis connection.
- *
- *  Must be called after configManager.setConfig, else the redisHost and redisPort
- *  would default and thus never used as intended.
- */
-export const initRedisConnection = () => {
-  const { redisHost, redisPort } = configManager.getConfig()
-
-  this.initial = redis.createClient(redisPort, redisHost, {
-    retry_strategy
-  })
-}
-
 const hookOnEvents = connection => {
   connection.on('error', err => {
     logger.error({ who: 'redis-driver', err })
@@ -60,7 +46,21 @@ const hookOnEvents = connection => {
   })
 }
 
-hookOnEvents(initial)
+/**
+ *  Create the initial Redis connection.
+ *
+ *  Must be called after configManager.setConfig, else the redisHost and redisPort
+ *  would default and thus never used as intended.
+ */
+export const initRedisConnection = () => {
+  const { redisHost, redisPort } = configManager.getConfig()
+
+  initial = redis.createClient(redisPort, redisHost, {
+    retry_strategy
+  })
+
+  hookOnEvents(initial)
+}
 
 export function UndefinedConnectionException(message) {
   this.message = message

--- a/packages/aquedux-server/src/redis/connections.js
+++ b/packages/aquedux-server/src/redis/connections.js
@@ -11,6 +11,7 @@ bluebird.promisifyAll(redis.RedisClient.prototype)
 bluebird.promisifyAll(redis.Multi.prototype)
 
 let connections = {}
+let initial = null
 
 const retry_strategy = options => {
   if (options.attempt > 3) {
@@ -21,12 +22,19 @@ const retry_strategy = options => {
   return Math.min(options.attempt * options.attempt * 100, 3000)
 }
 
-//TODO Maybe move it to a function called after initial config
-const { redisHost, redisPort } = configManager.getConfig()
+/**
+ *  Create the initial Redis connection.
+ *
+ *  Must be called after configManager.setConfig, else the redisHost and redisPort
+ *  would default and thus never used as intended.
+ */
+export const initRedisConnection = () => {
+  const { redisHost, redisPort } = configManager.getConfig()
 
-const initial = redis.createClient(redisPort, redisHost, {
-  retry_strategy
-})
+  this.initial = redis.createClient(redisPort, redisHost, {
+    retry_strategy
+  })
+}
 
 const hookOnEvents = connection => {
   connection.on('error', err => {


### PR DESCRIPTION
The initial Redis connection, from which all other connections result, was wrongly initialized.
 When the `redis/connections.js` file was loaded for the first time - before configManager.setConfig is called - the initial connection was made with the default host/port options. 